### PR TITLE
DOC: Enable doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ cache:
 
 matrix:
   include:
-    - python: 2.7
-      env:
-      - TOXENV=py27
     - python: 3.4
       env:
       - TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - TOXENV=flake8
   - TOXENV=pylint
   - TOXENV=docs
+  - TOXENV=doctest
   - TOXENV=check-manifest
   #- TOXENV=checkreadme
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,25 +19,38 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  #- TOXENV=py35
-  #- TOXENV=py36
-  - TOXENV=flake8
-  - TOXENV=pylint
-  - TOXENV=docs
-  - TOXENV=doctest
-  - TOXENV=check-manifest
-  #- TOXENV=checkreadme
 matrix:
   include:
+    - python: 2.7
+      env:
+      - TOXENV=py27
+    - python: 3.4
+      env:
+      - TOXENV=py34
     - python: 3.5
       env:
       - TOXENV=py35
     - python: 3.6
       env:
       - TOXENV=py36
+    - python: 3.5
+      env:
+      - TOXENV=flake8
+    - python: 3.5
+      env:
+      - TOXENV=pylint
+    - python: 3.5
+      env:
+      - TOXENV=docs
+    - python: 3.5
+      env:
+      - TOXENV=doctest
+    - python: 3.5
+      env:
+      - TOXENV=check-manifest
+    - python: 3.5
+      env:
+      - TOXENV=checkreadme
 
 before_install:
   - pip install codecov # for coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,6 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python27"
-      TOXENV: "py27"
-      TOXPYTHON: "%PYTHON%\\python.exe"
-
-    - PYTHON: "C:\\Python33"
-      TOXENV: "py33"
-      TOXPYTHON: "%PYTHON%\\python.exe"
-
     - PYTHON: "C:\\Python34"
       TOXENV: "py34"
       TOXPYTHON: "%PYTHON%\\python.exe"
@@ -33,14 +25,6 @@ environment:
 
     - PYTHON: "C:\\Python36"
       TOXENV: "py36"
-      TOXPYTHON: "%PYTHON%\\python.exe"
-
-    - PYTHON: "C:\\Python27-x64"
-      TOXENV: "py27"
-      TOXPYTHON: "%PYTHON%\\python.exe"
-
-    - PYTHON: "C:\\Python33-x64"
-      TOXENV: "py33"
       TOXPYTHON: "%PYTHON%\\python.exe"
 
     - PYTHON: "C:\\Python34-x64"

--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -50,12 +50,12 @@ with our dump function being::
 
     @registry.dumper(Experiment, "Experiment", version=1)
     def _exp_dump(experiment):
-        return {
-            "data": experiment.data,
-            "attrs": {
+        return DatasetContainer(
+            data=experiment.data,
+            attrs={
                 "time started": experiment.time_started
             }
-        }
+        )
 
 and our load function being::
 

--- a/docs/Usage.rst
+++ b/docs/Usage.rst
@@ -21,10 +21,14 @@ registry collection
     A collection of registries. Deals with choosing the correct registry, dumper
     and loader to use, including version locking.
 
-So a complete example based on the :ref:`quickstart` example is::
+So a complete example based on the :ref:`quickstart` example is:
+
+.. testcode::
 
     import numpy as np
-    from h5preserve import open as h5open, Registry, new_registry_list
+    from h5preserve import (
+        open as h5open, Registry, new_registry_list, DatasetContainer
+    )
 
     registry = Registry("experiment")
 
@@ -35,12 +39,12 @@ So a complete example based on the :ref:`quickstart` example is::
 
     @registry.dumper(Experiment, "Experiment", version=1)
     def _exp_dump(experiment):
-        return {
-            "data": experiment.data,
-            "attrs": {
+        return DatasetContainer(
+            data=experiment.data,
+            attrs={
                 "time started": experiment.time_started
             }
-        }
+        )
 
     @registry.loader("Experiment", version=1)
     def _exp_load(dataset):
@@ -51,16 +55,21 @@ So a complete example based on the :ref:`quickstart` example is::
 
     my_cool_experiment = Experiment(np.array([1,2,3,4,5]), 10)
 
-    with open("my_data_file.hdf5", new_registry_list(registry)) as f:
+    with h5open("my_data_file.hdf5", new_registry_list(registry)) as f:
         f["cool experiment"] = my_cool_experiment
 
-    with open("my_data_file.hdf5", new_registry_list(registry)) as f:
+    with h5open("my_data_file.hdf5", new_registry_list(registry)) as f:
         my_cool_experiment_loaded = f["cool experiment"]
 
     print(
         my_cool_experiment_loaded.time_started ==
         my_cool_experiment.time_started
     )
+
+.. testoutput::
+    :hide:
+
+    True
 
 Whilst for this simple case it's probably overkill to use :py:mod:`h5preserve`, :py:mod:`h5preserve` deals
 quite easily changing requirements, such as adding additional properties to

--- a/h5preserve/_utils.py
+++ b/h5preserve/_utils.py
@@ -7,8 +7,6 @@ Internal utilities for h5preserve
 """
 from collections import namedtuple, Callable
 
-import six
-
 from numpy import ndarray, number as npnumber, bool_ as npbool
 import h5py
 
@@ -35,9 +33,9 @@ H5PY_ATTR_WRITABLE_TYPES = {
     ndarray,
     npnumber,
     npbool,
+    str,
+    bytes,
 }
-H5PY_ATTR_WRITABLE_TYPES.add(six.text_type)
-H5PY_ATTR_WRITABLE_TYPES.add(six.binary_type)
 
 DumperMap = namedtuple("DumperMap", "label func")
 

--- a/h5preserve/additional_registries.py
+++ b/h5preserve/additional_registries.py
@@ -2,8 +2,6 @@
 """
 Additional registries for h5preserve
 """
-import six
-
 from numpy import asarray
 import h5py
 
@@ -46,20 +44,12 @@ builtin_numbers_registry.loader("float", version=None)(as_dataset_loader)
 bool_python_registry.dumper(bool, "bool", version=None)(as_dataset_dumper)
 bool_python_registry.loader("bool", version=None)(as_dataset_loader)
 
-if six.PY2:
-    builtin_text_registry.dumper(str, "ascii", version=None)(
-        as_dataset_dumper
-    )
-    builtin_text_registry.dumper(unicode, "text", version=None)(
-        as_dataset_dumper
-    )
-else:
-    builtin_text_registry.dumper(bytes, "ascii", version=None)(
-        as_dataset_dumper
-    )
-    builtin_text_registry.dumper(str, "text", version=None)(
-        as_dataset_dumper
-    )
+builtin_text_registry.dumper(bytes, "ascii", version=None)(
+    as_dataset_dumper
+)
+builtin_text_registry.dumper(str, "text", version=None)(
+    as_dataset_dumper
+)
 builtin_text_registry.loader("ascii", version=None)(as_dataset_loader)
 builtin_text_registry.loader("text", version=None)(as_dataset_loader)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,6 @@
-[wheel]
-universal=1
-
 [flake8]
 max-complexity = 15
 ignore=E226,N802,N803,N806,E402
-builtins=unicode
 
 [versioneer]
 VCS = git

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@ universal=1
 
 [flake8]
 max-complexity = 15
-# don't require spaces around math ops
 ignore=E226,N802,N803,N806,E402
+builtins=unicode
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
     install_requires = [
         "h5py",
     ],
+    python_requires = '>=3.4',
     author = "James Tocknell",
     author_email = "aragilar@gmail.com",
     description = "Thin wrapper around h5py, inspired by camel",
@@ -32,12 +33,11 @@ setuptools.setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Topic :: Scientific/Engineering',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
     ],
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py34,py35,py36,flake8,pylint,docs,check-manifest,checkreadme
+envlist = py34,py35,py36,flake8,pylint,docs,check-manifest,checkreadme
 
 [testenv]
 commands = py.test --cov={envsitepackagesdir}/h5preserve -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,12 @@ deps=-rdoc-requirements.txt
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
+[testenv:doctest]
+changedir=docs
+deps=-rdoc-requirements.txt
+commands=
+    sphinx-build -W -b doctest -d {envtmpdir}/doctrees .  {envtmpdir}/doctest
+
 [testenv:flake8]
 deps=flake8
 commands=


### PR DESCRIPTION
Enables doctest in tox and travis, and tests the main example in usage (it was broken previously), thanks @mattpitkin for picking this up.