### PR TITLE
DOC: Add project urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ setuptools.setup(
     license = "3-clause BSD",
     keywords = "hdf5",
     url = "https://h5preserve.readthedocs.io",
+    project_urls={
+        'Documentation': 'https://h5preserve.readthedocs.io',
+        'Source': 'https://github.com/h5preserve/h5preserve/',
+        'Tracker': 'https://github.com/h5preserve/h5preserve/issues',
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
setuptools has support for multiple different project urls, this adds the relevant urls to the setup.py. 